### PR TITLE
NECO-63: Added an installation method with CococaPods

### DIFF
--- a/MediaStorageSample/README.md
+++ b/MediaStorageSample/README.md
@@ -1,15 +1,16 @@
 # Media Storage Sample
 * In this sample, you can list your Media IDs.
 
-## Setup
-* Complete [Setup](https://github.com/ricohapi/media-storage-swift#setup) of Media Storage for Swift.
+## Using the Sample
+* Clone Ricoh Media Storage for Swift by running the following commands:
+```sh
+$ git clone --recursive https://github.com/ricohapi/MediaStorage.git
+```
+* Open `MediaStorageSample.xcworkspace` in the `MediaStorageSample` folder.
 * Fill your Credentials in `ViewController.swift`.
     * `"### enter your client ID ###"` : replace with your client ID.
     * `"### enter your client secret ###"` : replace with your client secret.
     * `"### enter your user id ###"` : replace with your user id.
     * `"### enter your user password ###"` : replace with your user password.
-
-## Using the Sample
 * Choose `MediaStorageSample` scheme at the scheme menu of Xcode.
 * Run `MediaStorageSample`.
-

--- a/MediaStorageSample/README.md
+++ b/MediaStorageSample/README.md
@@ -6,7 +6,7 @@
 ```sh
 $ git clone --recursive https://github.com/ricohapi/MediaStorage.git
 ```
-* Open `MediaStorageSample.xcworkspace` in the `MediaStorageSample` directory.
+* Open `MediaStorage.xcworkspace` in the `MediaStorage` directory.
 * Fill your Credentials in `ViewController.swift`.
     * `"### enter your client ID ###"` : replace with your client ID.
     * `"### enter your client secret ###"` : replace with your client secret.

--- a/MediaStorageSample/README.md
+++ b/MediaStorageSample/README.md
@@ -6,7 +6,7 @@
 ```sh
 $ git clone --recursive https://github.com/ricohapi/MediaStorage.git
 ```
-* Open `MediaStorageSample.xcworkspace` in the `MediaStorageSample` folder.
+* Open `MediaStorageSample.xcworkspace` in the `MediaStorageSample` directory.
 * Fill your Credentials in `ViewController.swift`.
     * `"### enter your client ID ###"` : replace with your client ID.
     * `"### enter your client secret ###"` : replace with your client secret.

--- a/README.md
+++ b/README.md
@@ -16,29 +16,52 @@ You'll also need
 
 If you don't have them, please register yourself and your client from [THETA Developers Website](http://contest.theta360.com/).
 
-## Setup
-* Clone Ricoh Media Storage for Swift and [Ricoh Auth Client for Swift](https://github.com/ricohapi/auth-swift) by running the following command:
+## Dependencies
+* [Ricoh Auth Client for Swift](https://github.com/ricohapi/auth-swift) 1.0+
+
+## Installation
+This section shows you two different methods to install Ricoh Media Storage for Swift in your application.  
+See [Media Storage Sample](https://github.com/ricohapi/media-storage-swift/tree/master/MediaStorageSample#media-storage-sample) to try out a sample of Ricoh Media Storage for Swift.
+
+### With CocoaPods
+* If it is your first time to use [CocoaPods](https://cocoapods.org/), run the following commands to set it up.
 ```sh
-$ git clone https://github.com/ricohapi/media-storage-swift.git
-$ git clone https://github.com/ricohapi/auth-swift.git
+$ gem install cocoapods
+$ pod setup
 ```
 
-* Open the `MediaStorage.xcodeproj` in the new `media-storage-swift` folder.
-* Open the new `auth-swift` folder, and drag the `RicohAPIAuth.xcodeproj` into the Project Navigator of `MediaStorage` project.
+* Move to your project directory.
+* Create a Podfile by running `pod init` ( if you do not have one yet ), and specify `MediaStorage` as follows:
+```sh
+source 'https://github.com/CocoaPods/Specs.git'
+platform :ios, '9.0'
+use_frameworks!
+
+target 'YourAppName' do
+  pod 'MediaStorage', '~> 1.0.0'
+end
+```
+* Run `pod install` to install `MediaStorage`.
+* Open your project's workspace.
+* Choose your application scheme and run it to load the MediaStorage module.
+* Install completed! See [Sample Flow](https://github.com/ricohapi/media-storage-swift#sample-flow) for a coding example.
+
+### Without CocoaPods
+* Clone Ricoh Media Storage for Swift by running the following commands:
+```sh
+$ git clone --recursive https://github.com/ricohapi/MediaStorage.git
+```
+* Open the new `media-storage-swift` folder, and drag `MediaStorage.xcodeproj` into the Project Navigator of your project.
 
     > It should appear nested underneath your application's blue project icon.
     > Whether it is above or below all the other Xcode groups does not matter.
 
 * Choose RicohAPIAuth scheme at the scheme menu of Xcode and run it.
-* Now you can try [Media Storage Sample](https://github.com/ricohapi/media-storage-swift/tree/master/MediaStorageSample).
-
-## Installation
-
-* Open the new `media-storage-swift` folder, and drag the `MediaStorage.xcodeproj` into the Project Navigator of your application's Xcode project.
-* Choose RicohAPIAuth scheme at the scheme menu of Xcode and run it. Same for MediaStorage scheme.
+* Choose MediaStorage scheme at the scheme menu of Xcode and run it.
+* Choose your application scheme and run it to load the MediaStorage module.
+* Install completed! See [Sample Flow](https://github.com/ricohapi/media-storage-swift#sample-flow) for a coding example.
 
 ## Sample Flow
-
 ```swift
 // Import
 import RicohAPIAuth

--- a/README.md
+++ b/README.md
@@ -23,30 +23,30 @@ If you don't have them, please register yourself and your client from [THETA Dev
 This section shows you two different methods to install Ricoh Media Storage for Swift in your application.  
 See [Media Storage Sample](https://github.com/ricohapi/media-storage-swift/tree/master/MediaStorageSample#media-storage-sample) to try out a sample of Ricoh Media Storage for Swift.
 
-### With CocoaPods
+### CocoaPods
 * If it is your first time to use [CocoaPods](https://cocoapods.org/), run the following commands to set it up.
 ```sh
 $ gem install cocoapods
 $ pod setup
 ```
 
-* Move to your project directory.
-* Create a Podfile by running `pod init` ( if you do not have one yet ), and specify `MediaStorage` as follows:
-```sh
+* Go to your project directory.
+* Create a Podfile by running `pod init` ( if you do not have one yet ), and specify `RicohapiMstorage` as follows:
+```ruby
 source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '9.0'
 use_frameworks!
 
 target 'YourAppName' do
-  pod 'MediaStorage', '~> 1.0.0'
+  pod 'RicohapiMstorage', '~> 1.0.0'
 end
 ```
-* Run `pod install` to install `MediaStorage`.
+* Run `pod install` to install `RicohapiMstorage`.
 * Open your project's workspace.
 * Choose your application scheme and run it to load the MediaStorage module.
 * Install completed! See [Sample Flow](https://github.com/ricohapi/media-storage-swift#sample-flow) for a coding example.
 
-### Without CocoaPods
+### Manually
 * Clone Ricoh Media Storage for Swift by running the following commands:
 ```sh
 $ git clone --recursive https://github.com/ricohapi/MediaStorage.git

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ end
 ```sh
 $ git clone --recursive https://github.com/ricohapi/MediaStorage.git
 ```
-* Open the new `media-storage-swift` folder, and drag `MediaStorage.xcodeproj` into the Project Navigator of your project.
+* Open the new `media-storage-swift` directory, and drag `MediaStorage.xcodeproj` into the Project Navigator of your project.
 
     > It should appear nested underneath your application's blue project icon.
     > Whether it is above or below all the other Xcode groups does not matter.


### PR DESCRIPTION
## Changes
- README.md 
  - Added an installation method with CococaPods.
  - Modified the existing installation method for "submodule".
  - Changed headlines to adjust the changes above.
  - Added a new part "Dependencies" to put a link to Auth Swift, referring [AlamofireImage](https://github.com/Alamofire/AlamofireImage#dependencies).
  - Fixed some grammatical mistakes.
- MediaStorageSample/README.md
  - Combined Setup and Using the Sample.
  - Modified  the existing installation method for "submodule".
## How It Looks Like
- [README.md](https://github.com/okunoyuki/media-storage-swift/tree/feature/NECO-63#ricoh-media-storage-for-swift)
- [MediaStorageSample/README.md](https://github.com/okunoyuki/media-storage-swift/tree/feature/NECO-63/MediaStorageSample#media-storage-sample)
## Tests
- Tested all the links which were newly added or modified.
